### PR TITLE
Add status log to left panel (Issue #23)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { apiService } from './services/api';
 import { WebSocketService } from './services/websocket';
 import type { GameState, ConnectionStatus, Vector2 } from './types';
 import SectorMap from './components/SectorMap';
+import StatusLog from './components/StatusLog';
 
 const App: React.FC = () => {
   const [gameState, setGameState] = useState<GameState | null>(null);
@@ -220,6 +221,19 @@ const App: React.FC = () => {
                     )}
                   </div>
                 ))}
+              </div>
+            </div>
+
+            {/* Status Log */}
+            <div className="card">
+              <div className="card-header">
+                <h3>Status Log</h3>
+              </div>
+              <div className="card-content" style={{ padding: 0 }}>
+                <StatusLog 
+                  events={gameState.events || []}
+                  shipNames={new Map(gameState.player.ships.map(ship => [ship.id, ship.name]))}
+                />
               </div>
             </div>
 

--- a/frontend/src/components/StatusLog.tsx
+++ b/frontend/src/components/StatusLog.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef } from 'react';
+import { GameEvent } from '../types';
+
+interface StatusLogProps {
+  events: GameEvent[];
+  shipNames: Map<string, string>;
+}
+
+const StatusLog: React.FC<StatusLogProps> = ({ events, shipNames }) => {
+  const logEndRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom when new events are added
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [events]);
+
+  const formatTime = (timestamp: number): string => {
+    const totalSeconds = Math.floor(timestamp / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  };
+
+  const formatLogEntry = (event: GameEvent): { time: string; reporter: string; message: string; className: string } => {
+    const time = formatTime(event.timestamp);
+    let reporter = 'System';
+    let message = event.message;
+    let className = 'log-entry';
+
+    // Extract ship name from event data or message
+    if (event.data?.shipId) {
+      reporter = shipNames.get(event.data.shipId as string) || 'Unknown Ship';
+    } else if (event.message.includes(' - ')) {
+      const parts = event.message.split(' - ');
+      if (parts.length > 1) {
+        reporter = parts[0];
+        message = parts.slice(1).join(' - ');
+      }
+    }
+
+    // Apply different styling based on event type
+    switch (event.type) {
+      case 'sector_changed':
+        className += ' log-sector-change';
+        // Parse message to match the required format
+        if (event.data?.fromSectorName && event.data?.toSectorName) {
+          message = `Jumped from ${event.data.fromSectorName} to ${event.data.toSectorName}`;
+        }
+        break;
+      case 'trade':
+      case 'trade_completed':
+        className += ' log-trade';
+        // Format trade message
+        if (event.data?.type && event.data?.stationName) {
+          const action = (event.data.type as string).toUpperCase();
+          const stationName = event.data.stationName as string;
+          const creditsBeforeTrade = event.data.creditsBeforeTrade as number;
+          const creditsAfterTrade = event.data.creditsAfterTrade as number;
+          const stationStockBefore = event.data.stationStockBefore as number;
+          const stationStockAfter = event.data.stationStockAfter as number;
+          const shipCargoBefore = event.data.shipCargoBefore as number;
+          const shipCargoAfter = event.data.shipCargoAfter as number;
+          
+          message = `${action} at ${stationName}: Credits ${creditsBeforeTrade} → ${creditsAfterTrade}, Station stock ${stationStockBefore} → ${stationStockAfter}, Ship cargo ${shipCargoBefore} → ${shipCargoAfter}`;
+        }
+        break;
+      case 'ship_command':
+        className += ' log-command';
+        break;
+      case 'ship_moved':
+        className += ' log-movement';
+        break;
+      case 'sector_discovered':
+        className += ' log-discovery';
+        break;
+      default:
+        className += ' log-default';
+    }
+
+    return { time, reporter, message, className };
+  };
+
+  return (
+    <div className="status-log">
+      <div className="status-log-content">
+        {events.map((event) => {
+          const { time, reporter, message, className } = formatLogEntry(event);
+          return (
+            <div key={event.id} className={className}>
+              <span className="log-time">[{time}]</span>
+              <span className="log-reporter">[{reporter}]</span>
+              <span className="log-message">{message}</span>
+            </div>
+          );
+        })}
+        <div ref={logEndRef} />
+      </div>
+    </div>
+  );
+};
+
+export default StatusLog;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -392,3 +392,84 @@ canvas {
 ::-webkit-scrollbar-thumb:hover {
   background-color: var(--text-secondary);
 }
+
+/* Status Log */
+.status-log {
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  margin-top: 16px;
+}
+
+.status-log-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  font-family: 'SF Mono', Monaco, 'Inconsolata', 'Roboto Mono', 'Source Code Pro', 'Menlo', 'Consolas', monospace;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.log-entry {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 2px;
+  align-items: flex-start;
+}
+
+.log-time {
+  color: var(--text-secondary);
+  min-width: 60px;
+  font-weight: 500;
+}
+
+.log-reporter {
+  color: var(--text-accent);
+  min-width: 80px;
+  font-weight: 600;
+}
+
+.log-message {
+  color: var(--text-primary);
+  flex: 1;
+}
+
+/* Log entry type styling */
+.log-sector-change .log-time {
+  color: var(--text-success);
+}
+
+.log-sector-change .log-message {
+  color: var(--text-success);
+}
+
+.log-trade .log-time {
+  color: var(--text-warning);
+}
+
+.log-trade .log-message {
+  color: var(--text-warning);
+}
+
+.log-command .log-time {
+  color: var(--text-accent);
+}
+
+.log-movement .log-time {
+  color: var(--text-secondary);
+}
+
+.log-discovery .log-time {
+  color: #ff79c6;
+}
+
+.log-discovery .log-message {
+  color: #ff79c6;
+}
+
+.log-default .log-time {
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary
- Add StatusLog component with terminal-style display to left panel
- Display game events with [time] [reporter] message format  
- Color-coded entries for different event types (sector changes, trades, commands)
- Auto-scroll functionality to show newest entries at bottom

## Implementation Details
- Created `StatusLog.tsx` component with proper event formatting
- Added CSS styling for terminal appearance with color coding
- Integrated into left panel below ships list in `App.tsx`
- Leverages existing GameEvent system from backend

## Test Plan
- [x] Build passes successfully
- [ ] Manual testing of sector jumps showing in log
- [ ] Manual testing of trade actions showing in log
- [ ] Verify auto-scroll behavior with multiple events
- [ ] Check color coding for different event types

🤖 Generated with [Claude Code](https://claude.ai/code)