### PR TITLE
Improve Status Log layout for better readability (Issue #23)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -398,7 +398,7 @@ canvas {
   background-color: var(--bg-primary);
   border: 1px solid var(--border-primary);
   border-radius: 6px;
-  height: 200px;
+  height: 600px;
   display: flex;
   flex-direction: column;
   margin-top: 16px;
@@ -414,27 +414,25 @@ canvas {
 }
 
 .log-entry {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 2px;
-  align-items: flex-start;
+  margin-bottom: 3px;
+  padding: 2px 0;
+  font-size: 11px;
+  line-height: 1.3;
 }
 
 .log-time {
   color: var(--text-secondary);
-  min-width: 60px;
   font-weight: 500;
 }
 
 .log-reporter {
   color: var(--text-accent);
-  min-width: 80px;
   font-weight: 600;
+  margin: 0 4px;
 }
 
 .log-message {
   color: var(--text-primary);
-  flex: 1;
 }
 
 /* Log entry type styling */


### PR DESCRIPTION
## Summary
• Increased Status Log height from 200px to 600px for better visibility
• Simplified log entry layout by removing flexbox and switching to inline layout
• Improved typography with smaller font size (11px) and better line height (1.3)
• Enhanced readability with refined spacing and margins

## Test plan
- [ ] Verify Status Log displays with increased height
- [ ] Check that log entries are properly formatted and readable
- [ ] Ensure typography improvements don't break existing functionality
- [ ] Test responsiveness of the layout changes

🤖 Generated with [Claude Code](https://claude.ai/code)